### PR TITLE
Fixed accesser path and optional arguments

### DIFF
--- a/jnihelper.sh
+++ b/jnihelper.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-NATIVE_ACCESSER_PATH='in/derros/jni/Utils.java'
-NATIVE_ACCESSER_CLASS_NAME='in.derros.jni.Utils'
+NATIVE_ACCESSER_PATH='in/derros/jni/Utilities.java'
+NATIVE_ACCESSER_CLASS_NAME='in.derros.jni.Utilities'
 PWD=`pwd`
+
 echo
 echo 'Java Native Interface Helper'
 echo 'Created by RJ Fang'
@@ -10,11 +11,12 @@ echo 'Options: ./jnihelper.sh'
 echo '--refresh-header     Refreshes the header'
 echo '--build              Tries CMake build'
 echo '--execute-java       Tests library'
+echo
 
 refresh_header () {
 
     cd java
-    javah $NATIVE_ACCESSER_PATH
+    javah $NATIVE_ACCESSER_CLASS_NAME
     cd ../
     echo "Generation finished."
 }
@@ -41,20 +43,19 @@ exej () {
 }
 
 
-if [ $1=='--refresh-header' ]
-then
+if [ "$1" != "" ]; then
+    while [ "$1" != "" ]; do
+        case $1 in
+            --refresh-header        )   refresh_header
+                                        ;;
+            --build                 )   buildj
+                                        ;;
+            --execute-java | --exej )   exej
+        esac
+        shift
+    done
+else
     refresh_header
-fi
-
-if [ $1=='--build' ]
-then
     buildj
-fi
-
-if [ $1=='--execute-java' ]
-then
     exej
 fi
-
-
-


### PR DESCRIPTION
Fixed NATIVE_ACCESSER_* incorrectly referenced a non-existed "Util" instead of "Utilities"
Fixed optional arguments having no affect. if then statements always executed. Also added support for multiple cl arguments.