### PR TITLE
Allow System.load regardless of project path

### DIFF
--- a/java/in/derros/jni/Utilities.java
+++ b/java/in/derros/jni/Utilities.java
@@ -1,19 +1,29 @@
 package in.derros.jni;
 
+import java.nio.file.FileSystems;
+
+
 class Utilities {
+    static {
+        // Ensure library is only loaded once
+        System.load(
+            FileSystems.getDefault()
+                       .getPath("./../build/libjnitests.so")
+                       .normalize().toAbsolutePath().toString());
+    }
 
     private native void printMethod();
     private native boolean trueFalse();
     private native int power(int b, int e);
     private native byte[] returnAByteArray();
     private native String stringManipulator(String s, String[] s1);
-    public Utilities() { System.load("/home/alex/Projects/jnitests/build/libjnitests.so"); }
 
     public void printUtil() { printMethod();  }
     public boolean boolTest() { return trueFalse();  }
     public int pow(int b, int e) {return power(b, e); }
     public byte[] testReturnBytes() { return returnAByteArray(); }
     public String manipulateStrings(String s, String[] s1) { return stringManipulator(s, s1);  }
+
     public static void main(String[] args) {
         Utilities util = new Utilities();
         util.printUtil();
@@ -23,6 +33,7 @@ class Utilities {
         for ( byte b : bs ) { System.out.println("A Byte is: " + b);  }
         System.out.println("THIS IS THE STRING MANIPULATOR!!");
         System.out.println(
-                util.manipulateStrings("asdfxvcbiojdasaisdf hello world,,,", args));
+                util.manipulateStrings("asdfxvcbiojdasaisdf hello world,,,",
+                args));
     }
 }


### PR DESCRIPTION
Moved System.load to static as recommended to ensure library is only loaded once.
Path passed to System.load is independent of the project path. Previously it had to be manually changed.