### PR TITLE
Allow use of static or dynamic linked libjnitests

### DIFF
--- a/java/in/derros/jni/Utilities.java
+++ b/java/in/derros/jni/Utilities.java
@@ -4,12 +4,41 @@ import java.nio.file.FileSystems;
 
 
 class Utilities {
+    // Ensure library is only loaded once
     static {
-        // Ensure library is only loaded once
-        System.load(
-            FileSystems.getDefault()
-                       .getPath("./../build/libjnitests.so")
-                       .normalize().toAbsolutePath().toString());
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            // Windows based
+            try {
+                System.load(
+                    FileSystems.getDefault()
+                            .getPath("./../build/libjnitests.dll")  // Dynamic link
+                            .normalize().toAbsolutePath().toString());
+            }
+            catch (UnsatisfiedLinkError e) {
+                System.load(
+                    FileSystems.getDefault()
+                            .getPath("./../build/libjnitests.lib")  // Static link
+                            .normalize().toAbsolutePath().toString());
+            }
+        }
+        else
+        {
+            // Unix based
+            try
+            {
+                System.load(
+                    FileSystems.getDefault()
+                            .getPath("./../build/libjnitests.so")  // Dynamic link
+                            .normalize().toAbsolutePath().toString());
+            }
+            catch (UnsatisfiedLinkError e)
+            {
+                System.load(
+                    FileSystems.getDefault()
+                            .getPath("./../build/libjnitests.a")  // Static link
+                            .normalize().toAbsolutePath().toString());
+            }
+        }
     }
 
     private native void printMethod();


### PR DESCRIPTION
Allow use of a static or dynamically linked libjnitests based of file extension.
Allow functionality for Windows or Linux based file extensions by using the "os.name" property.